### PR TITLE
Retire Kimi K2.6 and K2.7 Code

### DIFF
--- a/catalog/models.json
+++ b/catalog/models.json
@@ -290,7 +290,6 @@
       },
       "max_output": 32000,
       "fallback": [
-        "kimi-k2p7-code",
         "terra"
       ]
     },
@@ -321,52 +320,6 @@
       ]
     },
     {
-      "id": "accounts/fireworks/models/kimi-k2p7-code",
-      "label": "kimi-k2p7-code",
-      "vendor": "fireworks",
-      "window": 262000,
-      "vision": true,
-      "reasoning": true,
-      "_note": "Kimi K2.7 Code (Moonshot, Fireworks Day-0 2026-06-12): vision, 262K. TRIED as planner 2026-06-13, RETIRED \u2014 failed to synthesize a usable plan (incomplete/reasoning-soup output, same class as K2.6). Kept for reference; no role.",
-      "pinnable": true,
-      "group": "Kimi",
-      "desc": "Coding specialist",
-      "name": "Kimi K2.7 Code",
-      "www": {
-        "chat": true,
-        "order": 19,
-        "description": "Moonshot coding specialist with native vision and a 262K context window."
-      },
-      "max_output": 32000,
-      "fallback": [
-        "glm-5p2",
-        "terra"
-      ]
-    },
-    {
-      "id": "accounts/fireworks/models/kimi-k2p6",
-      "label": "kimi-k2p6",
-      "vendor": "fireworks",
-      "window": 262000,
-      "vision": true,
-      "reasoning": true,
-      "pinnable": true,
-      "group": "Kimi",
-      "_note": "Kimi K2.6 (Moonshot, Fireworks). Added 2026-07-17 for the /model pin picker. Native vision (MoonViT), 262K. VERIFY the Fireworks id spelling + window against the account before relying on it in prod.",
-      "desc": "General open-weight",
-      "name": "Kimi K2.6",
-      "www": {
-        "chat": true,
-        "order": 20,
-        "description": "Moonshot general open-weight model with native vision and a 262K context window."
-      },
-      "max_output": 32000,
-      "fallback": [
-        "kimi-k2p7-code",
-        "terra"
-      ]
-    },
-    {
       "id": "accounts/fireworks/models/kimi-k3",
       "label": "kimi-k3",
       "vendor": "fireworks",
@@ -388,7 +341,7 @@
       },
       "max_output": 32000,
       "fallback": [
-        "kimi-k2p7-code",
+        "glm-5p2",
         "terra"
       ]
     },
@@ -633,15 +586,6 @@
         "minimax-m3"
       ],
       "window": 500000
-    },
-    {
-      "match": [
-        "kimi-k2p7"
-      ],
-      "price_in": 0.95,
-      "price_out": 4.0,
-      "price_cache_read": 0.19,
-      "_note": "Kimi K2.7 real Fireworks card (LiteLLM 2026-07-27) \u2014 the glm floor overcharged kimi ~1.5x"
     },
     {
       "match": [

--- a/catalog/pricing_test.go
+++ b/catalog/pricing_test.go
@@ -23,8 +23,7 @@ func TestModelPricingRealIDs(t *testing.T) {
 		{"grok-4.6", 2, 6},
 		{"accounts/fireworks/models/glm-5p2", 1.40, 4.40}, // was $0
 		{"accounts/fireworks/models/glm-5p1", 1.40, 4.40},
-		{"accounts/fireworks/models/kimi-k3", 3.00, 15.00},       // K3's own Fireworks headline card ($3/$15), NOT the kimi family rule
-		{"accounts/fireworks/models/kimi-k2p7-code", 0.95, 4.00}, // pinnable via /model
+		{"accounts/fireworks/models/kimi-k3", 3.00, 15.00}, // K3's own Fireworks headline card ($3/$15), NOT the kimi family rule
 		{"accounts/fireworks/models/qwen3p8-2p4t-a95b", 2.00, 6.00},
 		{"accounts/fireworks/models/deepseek-v4-pro-0813", 1.32, 3.96},
 		{"accounts/fireworks/models/deepseek-v4-flash-0731", 0.22, 0.66},
@@ -56,7 +55,7 @@ func TestModelPricingByLabel(t *testing.T) {
 		in    float64
 	}{
 		{"sol", 5}, {"terra", 2}, {"luna", 0.2},
-		{"glm-5p2", 1.40}, {"kimi-k2p6", 0.95}, {"qwen3p8-max", 2.00},
+		{"glm-5p2", 1.40}, {"kimi-k3", 3.00}, {"qwen3p8-max", 2.00},
 		{"deepseek-v4-pro", 1.32}, {"deepseek-v4-flash", 0.22},
 		{"gemini-flash-lite", 0.3},
 	}
@@ -82,7 +81,7 @@ func TestContextWindowFireworks(t *testing.T) {
 		{"accounts/fireworks/models/glm-5p2", 1_000_000}, // was defaulting to 200K
 		{"accounts/fireworks/models/glm-5p1", 202_000},
 		{"accounts/fireworks/models/kimi-k3", 1_000_000}, // k3 ≠ the kimi-k2 262K case
-		{"accounts/fireworks/models/kimi-k2p6", 262_000},
+		{"accounts/fireworks/models/kimi-k3", 1_000_000},
 		{"accounts/fireworks/models/qwen3p8-2p4t-a95b", 262_144},
 		{"accounts/fireworks/models/deepseek-v4-pro-0813", 1_040_000},
 		{"accounts/fireworks/models/deepseek-v4-flash-0731", 1_040_000},
@@ -108,7 +107,7 @@ func TestModelPricingCacheRates(t *testing.T) {
 		{"claude-sonnet-5", 0.2, 2.5},
 		{"gpt-5.6-terra", 0.2, 2.5},
 		{"accounts/fireworks/models/glm-5p2", 0.14, 1.75},
-		{"accounts/fireworks/models/kimi-k2p6", 0.16, 1.1875},
+		{"accounts/fireworks/models/kimi-k3", 0.30, 3.75},
 		{"accounts/fireworks/models/qwen3p8-2p4t-a95b", 0.2, 2.5},
 		{"accounts/fireworks/models/deepseek-v4-pro-0813", 0.044, 1.32 * 1.25},
 		{"accounts/fireworks/models/deepseek-v4-flash-0731", 0.007, 0.275},

--- a/internal/agent/runtime/loop.go
+++ b/internal/agent/runtime/loop.go
@@ -1102,7 +1102,7 @@ func (s *Session) complete(ctx context.Context, purpose llm.Purpose, req wire.Re
 		if resp.Model != "" {
 			s.lastServedModel = resp.Model
 		}
-		// Just the model name — it already implies the backend (kimi-k2p6 = cheap lane, opus =
+		// Just the model name — it already implies the backend (glm-5p2 = cheap lane, opus =
 		// Anthropic). The cheap lane tags a short Pool label; Anthropic has none, so fall back to
 		// the short model id.
 		name := resp.Pool

--- a/internal/llm/delegated_test.go
+++ b/internal/llm/delegated_test.go
@@ -68,7 +68,7 @@ func TestDelegatedWorkerKeepsNormalFailureSemantics(t *testing.T) {
 	if _, err := worker2.Complete(context.Background(), Agent, userReq("work")); err != nil {
 		t.Fatalf("the declared chain must rescue a delegated worker too: %v", err)
 	}
-	if len(p2.requested) != 2 || p2.requested[1] != "kimi-k2p7-code" {
-		t.Fatalf("delegated fallback walk = %v, want [glm-5p2 kimi-k2p7-code]", p2.requested)
+	if len(p2.requested) != 2 || p2.requested[1] != "terra" {
+		t.Fatalf("delegated fallback walk = %v, want [glm-5p2 terra]", p2.requested)
 	}
 }

--- a/internal/llm/policy_test.go
+++ b/internal/llm/policy_test.go
@@ -206,9 +206,9 @@ func TestFallbackWalkOnModelError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("the chain must rescue the call: %v", err)
 	}
-	// glm-5p2 fails → catalog chain: kimi-k2p7-code.
-	if len(p.requested) != 2 || p.requested[1] != "kimi-k2p7-code" {
-		t.Fatalf("walk = %v, want [glm-5p2 kimi-k2p7-code]", p.requested)
+	// glm-5p2 fails → its declared chain: terra.
+	if len(p.requested) != 2 || p.requested[1] != "terra" {
+		t.Fatalf("walk = %v, want [glm-5p2 terra]", p.requested)
 	}
 	if !strings.HasPrefix(resp.FallbackReason, "model_error: ") {
 		t.Fatalf("reason = %q, want model_error: …", resp.FallbackReason)

--- a/internal/provider/uniformity_test.go
+++ b/internal/provider/uniformity_test.go
@@ -172,7 +172,7 @@ func assertUniformWire(t *testing.T, cs *compatServer, wantAuth string) {
 func TestBackendUniformity(t *testing.T) {
 	// ── (a) the gateway-shaped backend: hosted policy over the control plane ──
 	gw := &compatServer{gateway: true,
-		models:   []string{"sol", "terra", "luna", "opus", "sonnet", "haiku", "glm-5p2", "kimi-k2p7-code", "kimi-k2p6", "kimi-k3", "gpt-oss-120b"},
+		models:   []string{"sol", "terra", "luna", "opus", "sonnet", "haiku", "glm-5p2", "kimi-k3", "gpt-oss-120b"},
 		failOnce: map[string]bool{},
 	}
 	gwSrv := httptest.NewServer(gw.handler())

--- a/models.json
+++ b/models.json
@@ -290,7 +290,6 @@
       },
       "max_output": 32000,
       "fallback": [
-        "kimi-k2p7-code",
         "terra"
       ]
     },
@@ -321,52 +320,6 @@
       ]
     },
     {
-      "id": "accounts/fireworks/models/kimi-k2p7-code",
-      "label": "kimi-k2p7-code",
-      "vendor": "fireworks",
-      "window": 262000,
-      "vision": true,
-      "reasoning": true,
-      "_note": "Kimi K2.7 Code (Moonshot, Fireworks Day-0 2026-06-12): vision, 262K. TRIED as planner 2026-06-13, RETIRED \u2014 failed to synthesize a usable plan (incomplete/reasoning-soup output, same class as K2.6). Kept for reference; no role.",
-      "pinnable": true,
-      "group": "Kimi",
-      "desc": "Coding specialist",
-      "name": "Kimi K2.7 Code",
-      "www": {
-        "chat": true,
-        "order": 19,
-        "description": "Moonshot coding specialist with native vision and a 262K context window."
-      },
-      "max_output": 32000,
-      "fallback": [
-        "glm-5p2",
-        "terra"
-      ]
-    },
-    {
-      "id": "accounts/fireworks/models/kimi-k2p6",
-      "label": "kimi-k2p6",
-      "vendor": "fireworks",
-      "window": 262000,
-      "vision": true,
-      "reasoning": true,
-      "pinnable": true,
-      "group": "Kimi",
-      "_note": "Kimi K2.6 (Moonshot, Fireworks). Added 2026-07-17 for the /model pin picker. Native vision (MoonViT), 262K. VERIFY the Fireworks id spelling + window against the account before relying on it in prod.",
-      "desc": "General open-weight",
-      "name": "Kimi K2.6",
-      "www": {
-        "chat": true,
-        "order": 20,
-        "description": "Moonshot general open-weight model with native vision and a 262K context window."
-      },
-      "max_output": 32000,
-      "fallback": [
-        "kimi-k2p7-code",
-        "terra"
-      ]
-    },
-    {
       "id": "accounts/fireworks/models/kimi-k3",
       "label": "kimi-k3",
       "vendor": "fireworks",
@@ -388,7 +341,7 @@
       },
       "max_output": 32000,
       "fallback": [
-        "kimi-k2p7-code",
+        "glm-5p2",
         "terra"
       ]
     },
@@ -633,15 +586,6 @@
         "minimax-m3"
       ],
       "window": 500000
-    },
-    {
-      "match": [
-        "kimi-k2p7"
-      ],
-      "price_in": 0.95,
-      "price_out": 4.0,
-      "price_cache_read": 0.19,
-      "_note": "Kimi K2.7 real Fireworks card (LiteLLM 2026-07-27) \u2014 the glm floor overcharged kimi ~1.5x"
     },
     {
       "match": [


### PR DESCRIPTION
Removes Kimi K2.6 and Kimi K2.7 Code from the model catalog. Kimi K3 stays as the Kimi offering.

## Why the change is more than two deletions

Both models appeared in *other* models' declared fallback chains. A chain naming a model the catalog no longer contains resolves to nothing — it doesn't error, it just silently shortens the safety net that keeps a turn alive when a provider is unreachable. So the chains are repaired, not left dangling:

| model | before | after |
|---|---|---|
| `glm-5p2` | `kimi-k2p7-code, terra` | `terra` |
| `kimi-k3` | `kimi-k2p7-code, terra` | `glm-5p2, terra` |

`kimi-k3` keeps a same-provider hop that still exists rather than falling straight off Fireworks on its first failure.

The `kimi-k2p7` pricing family is removed along with the model it was written for. The generic `kimi` row stays as the floor, so a stale pin to a retired id still meters at roughly its real rate instead of dropping to the `$3/$15` defaults.

## What happens to someone pinned to one of them

Nothing breaks. A model id outside the catalog is refused by the `/model` picker and by policy validation, and the pin resolver falls through to the next scope — workspace, then user, then the `default_model` seed.

## Verification

- `gofmt`, `go vet`, `go test -race ./...`, `staticcheck` — the full CI gate, clean
- All four `models.json` copies verified byte-identical after `go generate ./catalog` and the sync script
- A structural check that every remaining `fallback` entry resolves to a model still in the catalog

## Note

The first attempt at this used index arithmetic over the JSON text and removed the wrong entry — `qwen3p8-2p4t-a95b` instead of `kimi-k2p6`. Caught by diffing the parsed catalog against `HEAD` rather than trusting the edit. Redone as a structural edit after verifying a JSON round-trip is byte-identical to the original file.

The matching www and gateway changes (catalog sync, FAQ, marketing model list, test fixtures) go direct to `main` in `memcode.ai`.